### PR TITLE
Ensure deliveries to kindle emails always send .mobi.

### DIFF
--- a/routes/api/books-v1.js
+++ b/routes/api/books-v1.js
@@ -65,11 +65,10 @@ router.get('/:id/download', (req, res) => {
 });
 
 router.get('/:id/email', (req, res) => {
-    const isMobi = req.query.filetype === 'mobi';
-
-    return RequestValidators.validateEmailRequest(req)
+    RequestValidators.validateEmailRequest(req)
         .then(() => Book.find(req.params.id, req.query.filetype))
         .then((book) => {
+            const isMobi = req.query.filetype === 'mobi';
             const mailerFn = isMobi ? Mailer.sendMobi : Mailer.sendEpub;
             return mailerFn(req.query.email, book).catch((error) => {
                 log.warn('Book delivery failed', req.query, error);

--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -1,5 +1,12 @@
 const AppErrors = require('../../lib/app-errors');
 
+function normalizeRequest(req) {
+    // Kindle's can only receive .mobi files
+    const isKindleEmail = /kindle/.test(req.query.email);
+    req.query.filetype = isKindleEmail ? 'mobi' : req.query.filetype;
+    return req;
+}
+
 class RequestValidators {
     static validatePublishRequest(req) {
         return new Promise((resolve, reject) => {
@@ -20,7 +27,8 @@ class RequestValidators {
             if (!req.query.email) {
                 reject(AppErrors.getApiError('NO_EMAIL_SPECIFIED'));
             } else {
-                resolve(req);
+                const normalizedRequest = normalizeRequest(req);
+                resolve(normalizedRequest);
             }
         });
     }

--- a/tests/integration/routes/api/books-api-test.js
+++ b/tests/integration/routes/api/books-api-test.js
@@ -331,6 +331,21 @@ const V1_ENDPOINTS = {
                 assert.deepEqual(Book.find.args, [['some-id', 'mobi']]);
             },
         },
+        {
+            get: { email: 'example@kindle.com', filetype: 'epub' },
+            status: 200,
+            response: 'Email sent!',
+            before: () => {
+                sandbox.stub(Book, 'find').resolves({ getMobiPath: () => {} });
+                sandbox.stub(Mailer, 'sendMobi').resolves({});
+                sandbox.stub(Mailer, 'sendEpub').resolves({});
+            },
+            after: () => {
+                assert.deepEqual(Book.find.args, [['some-id', 'mobi']]);
+                assert.isTrue(Mailer.sendMobi.called);
+                assert.isFalse(Mailer.sendEpub.called);
+            },
+        },
     ],
     '/api/v1/books/some-id/status': [
         {


### PR DESCRIPTION
### Previous Behavior

- User enters a kindle delivery email into EpubPress
- User does not change the filetype to `mobi`. 
- User clicks `Download`.
- EpubPress reports success, email is sent.
- Amazon/Kindle rejects the book because `epub` is invalid. Failure is completely hidden from user because email is sent from `no-reply@epub.press`. 

### New Behavior

- User triggers the send
- EpubPress notices the `kindle.com` email.
- Filetype is updated to `.mobi` in the background.
- Delivery should succeed because Kindle understands `.mobi`.