### PR TITLE
Fix missing package.json when building Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM node:carbon
 
 EXPOSE 3000
 WORKDIR /usr/src/epub-press
-RUN npm install
 
 COPY . .
+
+RUN npm install
+
 CMD ["npm", "run", "start:docker"]


### PR DESCRIPTION
`npm install` is now done after copying all files to the container. Otherwise `package.json` cannot be found and building the container fails with:

```npm WARN saveError ENOENT: no such file or directory, open '/usr/src/epub-press/package.json'```

