### PR TITLE
Configurable email server

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ Changes should be accompanied by tests. All tests located in `/tests`.
 | Download an ebook as a file               | `GET /api/v1/books/:id/download` |
 | Send the ebook to an email                | `GET /api/v1/books/:id/email`    |
 | Check versions compatible with the server | `GET /api/v1/version`            |
+
+### Environment variables
+
+ | Name                   | Default            | Description                       |
+ |------------------------|--------------------|-----------------------------------|
+ | `MAIL_SERVER_HOST`     |                    | Hostname of SMTP mail server      |
+ | `MAIL_SERVER_PORT`     |                    | Port of SMTP mail server          |
+ | `MAIL_SERVER_USERNAME` |                    | Username for SMTP authentication  |
+ | `MAIL_SERVER_PASSWORD` |                    | Password for SMTP authentication  |
+ | `MAIL_SENDER_ADDRESS`  | noreply@epub.press | Sender email address              |

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -8,17 +8,17 @@ const log = new Logger();
 
 // create reusable transporter object using the default SMTP transport
 const transporter = nodemailer.createTransport({
-    host: 'smtp.postmarkapp.com',
-    port: 2525,
+    host: process.env.MAIL_SERVER_HOST,
+    port: process.env.MAIL_SERVER_PORT,
     auth: {
-        user: process.env.EPUB_PRESS_EMAIL,
-        pass: process.env.EPUB_PRESS_PASSWORD,
+        user: process.env.MAIL_SERVER_USERNAME,
+        pass: process.env.MAIL_SERVER_PASSWORD,
     },
 });
 
 // setup e-mail data with unicode symbols
 const defaultMailOptions = {
-    from: '"EpubPress" <noreply@epub.press>', // sender address
+    from: `"EpubPress" <${process.env.MAIL_SENDER_ADDRESS || 'noreply@epub.press'}>`, // sender address
     to: '',
     subject: 'Your Ebook Is Ready', // Subject line
     html: '<p>The book you made with EpubPress is here!</p>',


### PR DESCRIPTION
To resolve #23 the SMTP transport is configurable via environment variables.

Note that I have changed the authentication environment variables `EPUB_PRESS_EMAIL` and `EPUB_PRESS_PASSWORD` to a more generic naming scheme.