### PR TITLE
Add HTTPs support with Lets Encrypt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           tags: latest,master
           cache_froms: haroldtreen/epub-press/server:latest
   deploy_stage:
-    if: ${{ github.ref == 'stage' }}
+    if: ${{ contains(github.ref, 'stage') }}
     runs-on: ubuntu-latest
     needs: [publish]
     steps:
@@ -70,7 +70,7 @@ jobs:
             docker-compose -f /usr/local/epub-press/docker-compose.stage.yaml up -d
             docker system prune -a -f
   deploy_prod:
-    if: ${{ github.ref == 'master' }}
+    if: ${{ contains(github.ref, 'master') }}
     runs-on: ubuntu-latest
     needs: [publish]
     steps:

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,8 +1,28 @@
 version: '3'
 services:
+  reverse-proxy:
+    image: traefik:v2.2
+    restart: unless-stopped
+    command: 
+      - "--api.insecure=false"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.server.acme.tlschallenge=true"
+      - "--certificatesresolvers.server.acme.email=epubpress@gmail.com"
+      - "--certificatesresolvers.server.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock
   server:
     image: docker.pkg.github.com/haroldtreen/epub-press/server:master
-    ports:
-        - "80:3000"
     env_file: envs/prod.env
     restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.epub-press.rule=Host(`epub.press`)
+      - traefik.http.routers.epub-press.entrypoints=websecure
+      - traefik.http.routers.epub-press.tls.certresolver=server

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -8,6 +8,9 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure" 
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--certificatesresolvers.server.acme.tlschallenge=true"
       - "--certificatesresolvers.server.acme.email=epubpress@gmail.com"
       - "--certificatesresolvers.server.acme.storage=/letsencrypt/acme.json"
@@ -24,5 +27,5 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.epub-press.rule=Host(`epub.press`)
-      - traefik.http.routers.epub-press.entrypoints=websecure
+      - traefik.http.routers.epub-press.entrypoints=web,websecure
       - traefik.http.routers.epub-press.tls.certresolver=server

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
     labels:
       - traefik.enable=true
-      - traefik.http.routers.epub-press.rule=Host(`server.docker.localhost`)
+      - traefik.http.routers.epub-press.rule=Host(`stage.epub.press`)
       - traefik.http.routers.epub-press.entrypoints=websecure
       - traefik.http.routers.epub-press.tls.certresolver=server
   postgres:

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -8,6 +8,9 @@ services:
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entryPoint.to=websecure" 
+      - "--entrypoints.web.http.redirections.entryPoint.scheme=https"
       - "--certificatesresolvers.server.acme.tlschallenge=true"
       - "--certificatesresolvers.server.acme.email=epubpress@gmail.com"
       - "--certificatesresolvers.server.acme.storage=/letsencrypt/acme.json"
@@ -26,7 +29,7 @@ services:
     labels:
       - traefik.enable=true
       - traefik.http.routers.epub-press.rule=Host(`stage.epub.press`)
-      - traefik.http.routers.epub-press.entrypoints=websecure
+      - traefik.http.routers.epub-press.entrypoints=web,websecure
       - traefik.http.routers.epub-press.tls.certresolver=server
   postgres:
     image: library/postgres

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -9,7 +9,6 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.websecure.address=:443"
       - "--certificatesresolvers.server.acme.tlschallenge=true"
-      - "--certificatesresolvers.server.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
       - "--certificatesresolvers.server.acme.email=epubpress@gmail.com"
       - "--certificatesresolvers.server.acme.storage=/letsencrypt/acme.json"
     ports:

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -2,6 +2,7 @@ version: '3'
 services:
   reverse-proxy:
     image: traefik:v2.2
+    restart: unless-stopped
     command: 
       - "--api.insecure=false"
       - "--providers.docker=true"

--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -1,17 +1,35 @@
 version: '3'
 services:
+  reverse-proxy:
+    image: traefik:v2.2
+    command: 
+      - "--api.insecure=false"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.server.acme.tlschallenge=true"
+      - "--certificatesresolvers.server.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.server.acme.email=epubpress@gmail.com"
+      - "--certificatesresolvers.server.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock
   server:
     image: docker.pkg.github.com/haroldtreen/epub-press/server:stage
-    ports:
-        - "80:3000"
     depends_on:
-        - postgres
+       - postgres
     env_file: envs/stage.env
     restart: unless-stopped
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.epub-press.rule=Host(`server.docker.localhost`)
+      - traefik.http.routers.epub-press.entrypoints=websecure
+      - traefik.http.routers.epub-press.tls.certresolver=server
   postgres:
     image: library/postgres
-    ports:
-        - "5432:5432"
     env_file: envs/stage.env
     restart: unless-stopped
     

--- a/scripts/deploy-stage.sh
+++ b/scripts/deploy-stage.sh
@@ -1,0 +1,3 @@
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+git update-ref refs/heads/stage refs/heads/$BRANCH_NAME
+git push -u origin stage -f


### PR DESCRIPTION
## Summary

We want secure connections - this adds a reverse proxy with LetsEncrypt.

## How to verify

- https://stage.epub.press/ is secure
- http://stage.epub.press/ redirects to the https version