### PR TITLE
fix: custom/external coverPath works

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ Changes should be accompanied by tests. All tests located in `/tests`.
 | Send the ebook to an email                | `GET /api/v1/books/:id/email`    |
 | Check versions compatible with the server | `GET /api/v1/version`            |
 
+#### Simple workflow
+```sh
+$ # create a book
+$ curl http://localhost:3000/api/v1/books \
+ -H "Content-Type: application/json" \
+ -X POST \
+ -d '{
+    "title": "A title",
+    "description": "A description",
+    "author": "An author",
+    "genre": "ebooks",
+    "coverPath": "https://via.placeholder.com/600x800.jpg?text=A%20Cover",
+    "urls": [
+        "https://epub.press"
+    ]
+}'
+
+{"id":"RXyGKmTq7"}
+$ # download the book
+$ curl -o book.ebub http://localhost:3000/api/v1/books/RXyGKmTq7/download
+$ ls
+book.ebub
+```
+
 ### Environment variables
 
  | Name                   | Default            | Description                       |

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -250,7 +250,9 @@ class BookServices {
                 book.setCoverPath(downloadPath);
                 return book;
             }).catch((err) => {
+                log.exception('BookServices.convertSectionContent')(err);
                 log.error(`downloading coverPath ${coverPath} failed`, err);
+                throw err;
             });
     }
 

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -16,6 +16,7 @@ const ResultsValidator = require('./results-validator');
 const Logger = require('./logger');
 const StatusTracker = require('./status-tracker');
 const StylingService = require('./styling-service');
+const ContentDownloader = require('./content-downloader');
 
 const tracker = new StatusTracker();
 const { STATUS_TYPES } = StatusTracker;
@@ -235,22 +236,16 @@ class BookServices {
             return StylingService.writeOnCover(book, book.getTitle());
         }
 
-        // any non-default is a remote cover
+        // any non-default is a remote cover        
         const coverPath = book.getCoverPath();
-        const coverFileName = `${book.getId()}-cover.png`;
-        const downloadPath = path.join(Config.COVERS_TMP, coverFileName);
+        const downloader = new ContentDownloader(coverPath, { path: Config.COVERS_TMP });
 
-        return request.get({
-            url: coverPath,
-            encoding: null,
-            resolveWithFullResponse: true,
-        })
+        return downloader.download()
             .then((response) => {
-                fs.writeFileSync(downloadPath, response.body);
-                book.setCoverPath(downloadPath);
+                book.setCoverPath(response.path);
                 return book;
             }).catch((err) => {
-                log.exception('BookServices.convertSectionContent')(err);
+                log.exception('BookServices.createCover')(err);
                 log.error(`downloading coverPath ${coverPath} failed`, err);
                 throw err;
             });

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -4,6 +4,8 @@ const { exec } = require('child_process');
 const request = require('request-promise').defaults({ gzip: true });
 const { tidy } = require('htmltidy2');
 const Promise = require('bluebird');
+const fs = require('fs');
+const path = require('path');
 
 const Config = require('./config');
 const AppErrors = require('./app-errors');
@@ -48,7 +50,7 @@ class BookServices {
             .then(BookServices.extractSectionsContent)
             .then(BookServices.localizeSectionsImages)
             .then(BookServices.convertSectionsContent)
-            .then(BookServices.createCustomCover)
+            .then(BookServices.createCover)
             .then(BookServices.writeEpub)
             .then(BookServices.convertToMobi)
             .then(BookServices.commit)
@@ -227,12 +229,29 @@ class BookServices {
         Step 6: Create a custom cover
     */
 
-    static createCustomCover(book) {
-        if (!book.hasCustomCover()) {
+    static createCover(book) {
+        if (book.hasDefaultCover()) {
             tracker.setStatus(book.getId(), STATUS_TYPES.CREATING_COVER);
             return StylingService.writeOnCover(book, book.getTitle());
         }
-        return Promise.resolve(book);
+
+        // any non-default is a remote cover
+        const coverPath = book.getCoverPath();
+        const coverFileName = `${book.getId()}-cover.png`;
+        const downloadPath = path.join(Config.COVERS_TMP, coverFileName);
+
+        return request.get({
+            url: coverPath,
+            encoding: null,
+            resolveWithFullResponse: true,
+        })
+            .then((response) => {
+                fs.writeFileSync(downloadPath, response.body);
+                book.setCoverPath(downloadPath);
+                return book;
+            }).catch((err) => {
+                log.error(`downloading coverPath ${coverPath} failed`, err);
+            });
     }
 
     /*

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -4,8 +4,6 @@ const { exec } = require('child_process');
 const request = require('request-promise').defaults({ gzip: true });
 const { tidy } = require('htmltidy2');
 const Promise = require('bluebird');
-const fs = require('fs');
-const path = require('path');
 
 const Config = require('./config');
 const AppErrors = require('./app-errors');
@@ -236,7 +234,7 @@ class BookServices {
             return StylingService.writeOnCover(book, book.getTitle());
         }
 
-        // any non-default is a remote cover        
+        // any non-default is a remote cover
         const coverPath = book.getCoverPath();
         const downloader = new ContentDownloader(coverPath, { path: Config.COVERS_TMP });
 

--- a/lib/book.js
+++ b/lib/book.js
@@ -203,8 +203,8 @@ class Book {
         return this.getMetadata().coverPath || Book.DEFAULT_COVER_PATH;
     }
 
-    hasCustomCover() {
-        return this.getCoverPath() !== Book.DEFAULT_COVER_PATH;
+    hasDefaultCover() {
+        return this.getCoverPath() === Book.DEFAULT_COVER_PATH;
     }
 
     getTags() {

--- a/lib/content-downloader.js
+++ b/lib/content-downloader.js
@@ -11,6 +11,14 @@ const DEFAULT_OPTIONS = {
     metadata: {},
 };
 
+/**
+ * @typedef ContentDownloaderOptions
+ * @type {object}
+ * @property {number} maxSize - maximum download size in bytes (default 1MB)
+ * @property {string} path - download destination folder
+ * @property {object} metadata - not used in download process. this object will be destructured and included in the response
+ */
+
 class ContentDownloader {
     static adjustMaxSizes(downloaders, maxSize) {
         const incomplete = downloaders.filter((d) => !d.isComplete());
@@ -47,6 +55,11 @@ class ContentDownloader {
         return false;
     }
 
+    /**
+     * 
+     * @param {string} url 
+     * @param {ContentDownloaderOptions} opts
+     */
     constructor(url, opts = {}) {
         this.url = url;
         this.status = { isComplete: false, size: 0 };

--- a/lib/content-downloader.js
+++ b/lib/content-downloader.js
@@ -16,7 +16,8 @@ const DEFAULT_OPTIONS = {
  * @type {object}
  * @property {number} maxSize - maximum download size in bytes (default 1MB)
  * @property {string} path - download destination folder
- * @property {object} metadata - not used in download process. this object will be destructured and included in the response
+ * @property {object} metadata - not used in download process.
+ *  this object will be destructured and included in the response
  */
 
 class ContentDownloader {
@@ -56,8 +57,8 @@ class ContentDownloader {
     }
 
     /**
-     * 
-     * @param {string} url 
+     *
+     * @param {string} url
      * @param {ContentDownloaderOptions} opts
      */
     constructor(url, opts = {}) {

--- a/tests/book-services-test.js
+++ b/tests/book-services-test.js
@@ -57,7 +57,7 @@ describe('Book Services', () => {
                 'extractSectionsContent',
                 'localizeSectionsImages',
                 'convertSectionsContent',
-                'createCustomCover',
+                'createCover',
                 'writeEpub',
                 'convertToMobi',
                 'commit',
@@ -82,24 +82,26 @@ describe('Book Services', () => {
         });
     });
 
-    describe('.createCustomCover', () => {
-        it('calls writeOnCover with the book title', () => {
+    describe('.createCover', () => {
+        it('calls writeOnCover with the book title with default cover path', () => {
             book = new Book();
             const writeOnCoverStub = Sinon.stub(StylingService, 'writeOnCover');
 
-            BookServices.createCustomCover(book);
+            BookServices.createCover(book);
             writeOnCoverStub.restore();
+            expect(writeOnCoverStub.callCount).toBe(1);
             const callArgs = writeOnCoverStub.firstCall.args;
             expect(callArgs[0]).toEqual(book);
             expect(callArgs[1]).toEqual(book.getTitle());
         });
 
-        it('skips if the book has a custom cover', async () => {
+        it('does not call writeOnCover if the book has a custom cover', async () => {
             book = new Book({ coverPath: 'https://images.com/an_image.jpg' });
+            const writeOnCoverStub = Sinon.stub(StylingService, 'writeOnCover');
 
-            const customizedBook = await BookServices.createCustomCover(book);
-
-            expect(customizedBook.getCoverPath()).toEqual('https://images.com/an_image.jpg');
+            await BookServices.createCover(book);
+            writeOnCoverStub.restore();
+            expect(writeOnCoverStub.callCount).toBe(0);
         });
     });
 

--- a/tests/book-test.js
+++ b/tests/book-test.js
@@ -106,17 +106,17 @@ describe('Book', () => {
         });
     });
 
-    describe('#hasCustomCover', () => {
-        it('returns true if a non-default cover is present', () => {
+    describe('#hasDefaultCover', () => {
+        it('returns false if a non-default cover is present', () => {
             book = new Book({ coverPath: 'https://custome.img' });
 
-            expect(book.hasCustomCover()).toBe(true);
+            expect(book.hasDefaultCover()).toBe(false);
         });
 
-        it('returns false if the book is using the default cover', () => {
+        it('returns true if the book is using the default cover', () => {
             book = new Book();
 
-            expect(book.hasCustomCover()).toBe(false);
+            expect(book.hasDefaultCover()).toBe(true);
         });
     });
 


### PR DESCRIPTION
https://github.com/haroldtreen/epub-press/commit/c3e3b32e834567df7ee0a3b6f0633d81a8054bbe broke externalCover paths. An assumption was made on my part that nodepub was downloading the image but in reality `createCustomCover` was doing it. 

This fixes the issue by downloading the external coverPath and referencing it locally for nodepub to access. 

This maintains the feature to only write the title of the book on the coverPage when it is the default. 

* download the custom image for coverPath to the tmp/covers directory
* rename hasCustomCover and createCustom
* update tests