### PR TITLE
chore: clean up CI warnings plus pattern for debugging tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,5 +35,15 @@
         "mocha": true,
         "browser": true,
         "jest": true,
-    }
+    },
+    "overrides": [
+        {
+            "files": ["scripts/**/*.js"],
+            "rules": {
+                "no-console": "off"
+            }
+        }
+    ]
+        
+    
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build
 on: [push, pull_request]
 jobs:
   test_and_lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Use Node.js 14
         uses: actions/setup-node@v1
@@ -22,7 +22,7 @@ jobs:
           coverageLocations: ${{ github.workspace }}/coverage/lcov.info:lcov
   publish:
     if: ${{ contains(github.ref, 'master') || contains(github.ref, 'stage') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [test_and_lint]
     steps:
       - uses: actions/checkout@v2
@@ -38,7 +38,7 @@ jobs:
           cache_froms: haroldtreen/epub-press/server:latest
   deploy_stage:
     if: ${{ contains(github.ref, 'stage') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [publish]
     steps:
       - uses: actions/checkout@v2
@@ -71,7 +71,7 @@ jobs:
             docker system prune -a -f
   deploy_prod:
     if: ${{ contains(github.ref, 'master') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [publish]
     steps:
       - uses: actions/checkout@v2

--- a/tests/html-processor-test.js
+++ b/tests/html-processor-test.js
@@ -3,6 +3,7 @@
 const glob = require('glob');
 const fs = require('fs-extra');
 const nock = require('nock');
+const debug = require('debug')('epub-press:tests');
 
 const Config = require('../lib/config');
 const Utilities = require('../lib/utilities');
@@ -11,6 +12,8 @@ const HtmlProcessor = require('../lib/html-processor.js');
 
 const fixturesPath = './tests/fixtures';
 const outputFolder = Config.IMAGES_TMP;
+
+debug(`outputFolder: ${outputFolder}`);
 
 describe('HTML Processor', () => {
     let mockSection;
@@ -320,7 +323,9 @@ describe('HTML Processor', () => {
             HtmlProcessor.extractImages(mockSection.url, mockSection.html)
                 .then(() => {
                     fs.readdir(outputFolder, (err, files) => {
-                        expect((files || []).length).toBe(4);
+                        const fileCount = (files || []).length;
+                        debug(`fileCount: ${fileCount}`);
+                        expect(fileCount).toBe(4);
                         done();
                     });
                 })


### PR DESCRIPTION
Wanted to get warnings cleaned up before I start making larger changes. This disables `no-console` when linting the JS files in `scripts` and pins GH actions to `ubuntu-18.04` instead of `ubuntu-latest`. 

Additionally I found a brittle test with html-processor and added a reference usage of the `debug` npm package for getting extra information on tests. 