### PR TITLE
Pin node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:12
 
 EXPOSE 3000
 WORKDIR /usr/src/epub-press


### PR DESCRIPTION
Previously the node version was `lts`. It looks like since the last deploy that version has incremented by two major versions. When using node 14, I see this error

```
 (node:45) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
server_1         | (Use `node --trace-warnings ...` to show where the warning was created)
```

It looks like some property used by dependencies don't exist in Node 14.

Should pin to a node that is known to work until a fix is found.