### PR TITLE
remove cover path URL from README example because it throws a certificate error

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ curl http://localhost:3000/api/v1/books \
     "description": "A description",
     "author": "An author",
     "genre": "ebooks",
-    "coverPath": "https://via.placeholder.com/600x800.jpg?text=A%20Cover",
+    "coverPath": "",
     "urls": [
         "https://epub.press"
     ]


### PR DESCRIPTION
If I execute the curl command in the example, no book is created and this error is thrown: 

```
GET /api/v1/books/j2dL3OOo7/download 404 25.539 ms - 72
server_1         | POST /api/v1/books 202 7.410 ms - 18
server_1         | error: Error Thrown @ BookServices.createCover: Error: certificate has expired
server_1         |  error=Error: certificate has expired
server_1         |     at TLSSocket.onConnectSecure (_tls_wrap.js:1502:34)
server_1         |     at TLSSocket.emit (events.js:314:20)
server_1         |     at TLSSocket._finishInit (_tls_wrap.js:937:8)
server_1         |     at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:711:12)
server_1         | error: downloading coverPath https://via.placeholder.com/600x800.jpg?text=A%20Cover failed message=certificate has expired, stack=Error: certificate has expired
server_1         |     at TLSSocket.onConnectSecure (_tls_wrap.js:1502:34)
server_1         |     at TLSSocket.emit (events.js:314:20)
server_1         |     at TLSSocket._finishInit (_tls_wrap.js:937:8)
server_1         |     at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:711:12), code=CERT_HAS_EXPIRED
```

I also get a certificate error if I try to open the URL in the browser. That's why I propose to remove the URL. 
