### PR TITLE
Content Type Checks

### DIFF
--- a/docker-compose.stage.yaml
+++ b/docker-compose.stage.yaml
@@ -50,7 +50,7 @@ services:
       - traefik.http.routers.metrics.rule=Host(`${SERVICE_HOST}`)
       - traefik.http.middlewares.auth.basicauth.users=${BASIC_AUTH_USERS}
   postgres:
-    image: library/postgres
+    image: library/postgres:12
     env_file: envs/stage.env
     restart: unless-stopped
     

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,7 @@ services:
       - "traefik.http.routers.metrics.rule=Host(`localhost`, `127.0.0.1`)"
       - "traefik.http.middlewares.auth.basicauth.users=${BASIC_AUTH_USERS}"
   postgres:
-    image: library/postgres
+    image: library/postgres:12
     ports:
         - "5432:5432"
     environment: 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,6 +12,7 @@ Constants.FILE_TYPES = {
     'image/svg': '.svg',
     'image/gif': '.gif',
     'text/html; charset=utf-8': '.html',
+    'text/html': '.html',
 };
 
 Constants.INVALID_ATTRIBUTES = [

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -11,6 +11,7 @@ Constants.FILE_TYPES = {
     'image/svg+xml': '.svg',
     'image/svg': '.svg',
     'image/gif': '.gif',
+    'text/html; charset=utf-8': '.html',
 };
 
 Constants.INVALID_ATTRIBUTES = [

--- a/lib/content-downloader.js
+++ b/lib/content-downloader.js
@@ -143,7 +143,6 @@ class ContentDownloader {
                 contentLength: this.getSize(),
                 contentType: response.headers['content-type'],
             };
-
             if (!ContentDownloader.isValidResponse(response)) {
                 resolve(result);
             } else {

--- a/lib/html-processor.js
+++ b/lib/html-processor.js
@@ -27,7 +27,8 @@ class HtmlProcessor {
         $('img').each((index, elem) => {
             const result = imgStatuses.find((status) => status.src === $(elem).attr('src'));
 
-            if (result && !result.error && result.path) {
+            const isImageResult = /\.(gif|png|jpg|jpeg|svg)/.test(result && result.path);
+            if (result && !result.error && result.path && isImageResult) {
                 const bookPath = result.path.replace(/.*(images\/.*)/, '../$1');
                 $(elem).attr('src', bookPath);
 

--- a/scripts/publish-html-file.js
+++ b/scripts/publish-html-file.js
@@ -1,0 +1,21 @@
+/*
+Publish HTML File
+
+Script for publishing random local html files.
+node scripts/publish-html-file.js <path_to_html> [url]
+
+Useful for debugging one off blocks of html.
+*/
+
+const fs = require('fs');
+const Book = require('../lib/book');
+const BookServices = require('../lib/book-services');
+
+const html = fs.readFileSync(process.argv[2], 'UTF-8');
+
+const book = Book.fromJSON({
+    title: 'HTML File Test',
+    sections: [{ url: process.argv[3] || 'https://epub.press', html }],
+});
+
+BookServices.publish(book);

--- a/tests/html-processor-test.js
+++ b/tests/html-processor-test.js
@@ -308,7 +308,7 @@ describe('HTML Processor', () => {
         });
 
         afterEach(() => {
-            glob(`${outputFolder}/*.png`, (err, files) => {
+            glob(`${outputFolder}/*.@(png|html)`, (err, files) => {
                 Utilities.removeFiles(files);
             });
         });
@@ -328,6 +328,23 @@ describe('HTML Processor', () => {
                         expect(fileCount).toBe(4);
                         done();
                     });
+                })
+                .catch(done);
+        });
+
+        it('detects when non-image content is returned', (done) => {
+            scope = nock('http://test.fake');
+            scope
+                .get('/image.png')
+                .replyWithFile(200, `${fixturesPath}/placeholder.png`, {
+                    'Content-Type': 'text/html;',
+                });
+
+            HtmlProcessor.extractImages(mockSection.url, '<div><img src="/image.png /></div>')
+                .then((output) => {
+                    expect(output.html).toEqual('<div></div>');
+                    expect(output.images).toHaveLength(0);
+                    done();
                 })
                 .catch(done);
         });

--- a/tests/html-processor-test.js
+++ b/tests/html-processor-test.js
@@ -332,18 +332,17 @@ describe('HTML Processor', () => {
                 .catch(done);
         });
 
-        it('detects when non-image content is returned', (done) => {
+        it('filters non-image content', (done) => {
             scope = nock('http://test.fake');
-            scope
-                .get('/image.png')
-                .replyWithFile(200, `${fixturesPath}/placeholder.png`, {
-                    'Content-Type': 'text/html;',
-                });
+            scope.get('/not-image.png').replyWithFile(200, `${fixturesPath}/article.html`, {
+                'Content-type': 'text/html',
+            });
 
-            HtmlProcessor.extractImages(mockSection.url, '<div><img src="/image.png /></div>')
+            HtmlProcessor.extractImages(mockSection.url, '<div><img src="/not-image.png" /></div>')
                 .then((output) => {
                     expect(output.html).toEqual('<div></div>');
                     expect(output.images).toHaveLength(0);
+                    scope.isDone();
                     done();
                 })
                 .catch(done);


### PR DESCRIPTION
User reported a their ereader wasn't able to open files from a certain site.

Investigated and turns out the image files were getting HTML responses that were being bundled as `png` files. 

This updates the content downloader to recognize HTML content types and the image extraction to filter non image downloads.