### PR TITLE
allow max number of ebook sections to be configurable 

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,6 +26,7 @@ services:
         - DB_HOST=postgres
         - DB_USERNAME=postgres
         - DB_PASSWORD=password
+        - MAX_NUM_SECTIONS=50
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.server.entrypoints=web,websecure"

--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -34,6 +34,10 @@ class RequestValidators {
     }
 }
 
-RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS ?? 50;
+if(process.env.MAX_NUM_SECTIONS){
+    RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS;
+} else {
+    RequestValidators.MAX_NUM_SECTIONS =  50;
+}
 
 module.exports = RequestValidators;

--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -34,6 +34,6 @@ class RequestValidators {
     }
 }
 
-RequestValidators.MAX_NUM_SECTIONS = 50;
+RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS;
 
 module.exports = RequestValidators;

--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -34,6 +34,6 @@ class RequestValidators {
     }
 }
 
-RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS;
+RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS ?? 50;
 
 module.exports = RequestValidators;

--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -34,10 +34,10 @@ class RequestValidators {
     }
 }
 
-if(process.env.MAX_NUM_SECTIONS){
+if (process.env.MAX_NUM_SECTIONS) {
     RequestValidators.MAX_NUM_SECTIONS = process.env.MAX_NUM_SECTIONS;
 } else {
-    RequestValidators.MAX_NUM_SECTIONS =  50;
+    RequestValidators.MAX_NUM_SECTIONS = 50;
 }
 
 module.exports = RequestValidators;


### PR DESCRIPTION
create MAX_NUM_SECTIONS env in case users want to use more than 50 sections so they can simply edit docker-compose.yaml to increase the limit
Remember to do docker-compose build to pick up the changes!