### PR TITLE
Add Calibre as default for MOBI conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ WORKDIR /usr/src/epub-press
 COPY package.json package-lock.json ./
 RUN npm install --production
 
+# Automatically downloads and installs Calibre. To use Kindlegen instead, set ARG converter=kindlegen.
+ARG converter=calibre
+ENV CONVERSION_BACKEND=$converter
+RUN if [ "$converter" = "calibre" ] ; then apt-get update && apt-get install -y libgl1-mesa-glx | wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=calibre-bin/ isolated=y ; fi
+
+
 COPY . .
 
 CMD ["npm", "run", "start:docker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install --production
 # Automatically downloads and installs Calibre. To use Kindlegen instead, set ARG converter=kindlegen.
 ARG converter=calibre
 ENV CONVERSION_BACKEND=$converter
-RUN if [ "$converter" = "calibre" ] ; then apt-get update && apt-get install -y libgl1-mesa-glx && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh && sh /dev/stdin install_dir=calibre-bin/ isolated=y ; fi
+RUN if [ "$converter" = "calibre" ] ; then apt-get update && apt-get install -y libgl1-mesa-glx && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=calibre-bin/ isolated=y ; fi
 
 
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install --production
 # Automatically downloads and installs Calibre. To use Kindlegen instead, set ARG converter=kindlegen.
 ARG converter=calibre
 ENV CONVERSION_BACKEND=$converter
-RUN if [ "$converter" = "calibre" ] ; then apt-get update && apt-get install -y libgl1-mesa-glx | wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin install_dir=calibre-bin/ isolated=y ; fi
+RUN if [ "$converter" = "calibre" ] ; then apt-get update && apt-get install -y libgl1-mesa-glx && wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh && sh /dev/stdin install_dir=calibre-bin/ isolated=y ; fi
 
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ book.epub
 | `MAIL_SERVER_USERNAME` |                    | Username for SMTP authentication                                                          |
 | `MAIL_SERVER_PASSWORD` |                    | Password for SMTP authentication                                                          |
 | `MAIL_SENDER_ADDRESS`  | noreply@epub.press | Sender email address                                                                      |
+| `MAX_NUM_SECTIONS`     | 50                 | Sets the maximum number of articles in one book.    
 
 Build argument (in Dockerfile):
 

--- a/README.md
+++ b/README.md
@@ -89,19 +89,24 @@ $ curl http://localhost:3000/api/v1/books \
 
 {"id":"RXyGKmTq7"}
 $ # download the book as epub file 
-$ curl -o book.ebub http://localhost:3000/api/v1/books/RXyGKmTq7/download
+$ curl -o book.epub http://localhost:3000/api/v1/books/RXyGKmTq7/download
 $ # or download as mobi file
 $ curl -o book.mobi "http://localhost:3000/api/v1/books/RXyGKmTq7/download?filetype=mobi"
 $ ls
-book.ebub
+book.epub
 ```
 
 ### Environment variables
 
-| Name                   | Default            | Description                       |
-|------------------------|--------------------|-----------------------------------|
-| `MAIL_SERVER_HOST`     |                    | Hostname of SMTP mail server      |
-| `MAIL_SERVER_PORT`     |                    | Port of SMTP mail server          |
-| `MAIL_SERVER_USERNAME` |                    | Username for SMTP authentication  |
-| `MAIL_SERVER_PASSWORD` |                    | Password for SMTP authentication  |
-| `MAIL_SENDER_ADDRESS`  | noreply@epub.press | Sender email address              |
+| Name                   | Default            | Description                                                                               |
+|------------------------|--------------------|-------------------------------------------------------------------------------------------|
+| `MAIL_SERVER_HOST`     |                    | Hostname of SMTP mail server                                                              |
+| `MAIL_SERVER_PORT`     |                    | Port of SMTP mail server                                                                  |
+| `MAIL_SERVER_TLS`      |                    | Leave blank by default. If using SSL/TLS for the SMTP connection, set the value to "yes". |
+| `MAIL_SERVER_USERNAME` |                    | Username for SMTP authentication                                                          |
+| `MAIL_SERVER_PASSWORD` |                    | Password for SMTP authentication                                                          |
+| `MAIL_SENDER_ADDRESS`  | noreply@epub.press | Sender email address                                                                      |
+
+Build argument (in Dockerfile):
+
+`converter` - leave as "calibre" to download and use Calibre for MOBI conversion (the setup for which assumes by default that the host is Debian-like). If not, or if there are errors, change the value of this variable to "kindlegen" to use the binaries in `/bin/`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ book.epub
 |------------------------|--------------------|-------------------------------------------------------------------------------------------|
 | `MAIL_SERVER_HOST`     |                    | Hostname of SMTP mail server                                                              |
 | `MAIL_SERVER_PORT`     |                    | Port of SMTP mail server                                                                  |
-| `MAIL_SERVER_TLS`      |                    | Leave blank by default. If using SSL/TLS for the SMTP connection, set the value to "yes". |
+| `MAIL_SERVER_TLS`      |                    | Leave blank by default. If using SSL/TLS for the SMTP connection, set the value to `true`.|
 | `MAIL_SERVER_USERNAME` |                    | Username for SMTP authentication                                                          |
 | `MAIL_SERVER_PASSWORD` |                    | Password for SMTP authentication                                                          |
 | `MAIL_SENDER_ADDRESS`  | noreply@epub.press | Sender email address                                                                      |

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -274,7 +274,7 @@ class BookServices {
     /*
         Step 7: Convert to .mobi
     */
-    
+
     static convertToMobi(book) {
         return new Promise((resolve, reject) => {
             const kindlegenCommand = `${Config.KINDLEGEN} "${book.getEpubPath()}"`;

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -121,7 +121,7 @@ class BookServices {
         updatedSection.content = '<h1>Oops! No content found.</h1>';
         updatedSection.content += [
             `<p>We looked for content in ${section.url} but couldn't find anything :(.</p>`,
-            '<p>Try making sure all your tabs have fully loaded before downloding your book.</p>',
+            '<p>Try making sure all your tabs have fully loaded before downloading your book.</p>',
             '<p>Feel free to email support@epub.press if you need help.</p>',
         ].join('\n');
 
@@ -227,7 +227,7 @@ class BookServices {
     }
 
     /*
-        Step 6: Create a custom cover
+        Step 5: Create a custom cover
     */
 
     static createCover(book) {
@@ -254,7 +254,7 @@ class BookServices {
     }
 
     /*
-        Step 5: Write Epub
+        Step 6: Write Epub
     */
 
     static writeEpub(book) {
@@ -272,12 +272,15 @@ class BookServices {
     }
 
     /*
-        Step 6: Convert to .mobi
+        Step 7: Convert to .mobi
     */
-
+    
     static convertToMobi(book) {
         return new Promise((resolve, reject) => {
-            exec(`${Config.KINDLEGEN} "${book.getEpubPath()}"`, (error) => {
+            const kindlegenCommand = `${Config.KINDLEGEN} "${book.getEpubPath()}"`;
+            const calibreCommand = `calibre-bin/calibre/ebook-convert "${book.getEpubPath()}" "${book.getMobiPath()}" "--mobi-file-type=both" "--duplicate-links-in-toc"`;
+            const conversionCommand = process.env.CONVERSION_BACKEND === 'calibre' ? calibreCommand : kindlegenCommand;
+            exec(conversionCommand, (error) => {
                 if (error && error.code > 1) {
                     log.exception('BookServices.convertToMobi')(error);
                     reject(error);
@@ -289,7 +292,7 @@ class BookServices {
     }
 
     /*
-        Step 7: Commit to DB
+        Step 8: Commit to DB
     */
 
     static commit(book) {
@@ -305,7 +308,7 @@ class BookServices {
     }
 
     /*
-        Step 8: Schedule Clean
+        Step 9: Schedule Clean
     */
 
     static scheduleClean(book) {

--- a/lib/book-services.js
+++ b/lib/book-services.js
@@ -281,7 +281,7 @@ class BookServices {
             const calibreCommand = `calibre-bin/calibre/ebook-convert "${book.getEpubPath()}" "${book.getMobiPath()}" "--mobi-file-type=both" "--duplicate-links-in-toc"`;
             const conversionCommand = process.env.CONVERSION_BACKEND === 'calibre' ? calibreCommand : kindlegenCommand;
             exec(conversionCommand, (error) => {
-                if (error && error.code > 1) {
+                if (error && error.code !== 0) {
                     log.exception('BookServices.convertToMobi')(error);
                     reject(error);
                 } else {

--- a/lib/mailer.js
+++ b/lib/mailer.js
@@ -10,6 +10,7 @@ const log = new Logger();
 const transporter = nodemailer.createTransport({
     host: process.env.MAIL_SERVER_HOST,
     port: process.env.MAIL_SERVER_PORT,
+    secure: process.env.MAIL_SERVER_TLS,
     auth: {
         user: process.env.MAIL_SERVER_USERNAME,
         pass: process.env.MAIL_SERVER_PASSWORD,


### PR DESCRIPTION
PR should resolve #77.

The commits in this pull request download and use Calibre as the default for MOBI conversion, with the option to switch to Kindlegen by changing an build ARG in the Dockerfile.

This also adds an ENV_VAR to start a SMTP connection with TLS (leaving it blank (default) will lead to a plain-text connection with an attempt to use STARTTLS). Documentation from Nodemailer for this is [here](https://nodemailer.com/smtp/#:~:text=TLS%20options,secure).

Documentation for these changes has also been added to the README.