### PR TITLE
Remove kindle email logic

### DIFF
--- a/routes/helpers/request-validators.js
+++ b/routes/helpers/request-validators.js
@@ -1,9 +1,7 @@
 const AppErrors = require('../../lib/app-errors');
 
 function normalizeRequest(req) {
-    // Kindle's can only receive .epub files
-    const isKindleEmail = /kindle/.test(req.query.email);
-    req.query.filetype = isKindleEmail ? 'epub' : req.query.filetype;
+    // Previously used to force a filetype for kindle.
     return req;
 }
 

--- a/tests/integration/routes/api/books-api-test.js
+++ b/tests/integration/routes/api/books-api-test.js
@@ -340,9 +340,9 @@ const V1_ENDPOINTS = {
                 sandbox.stub(Mailer, 'sendEpub').resolves({});
             },
             after: () => {
-                expect(Book.find.args).toEqual([['some-id', 'epub']]);
-                expect(Mailer.sendMobi.called).toBe(false);
-                expect(Mailer.sendEpub.called).toBe(true);
+                expect(Book.find.args).toEqual([['some-id', 'mobi']]);
+                expect(Mailer.sendMobi.called).toBe(true);
+                expect(Mailer.sendEpub.called).toBe(false);
             },
         },
     ],


### PR DESCRIPTION
## Context

In the beginning Kindle didn't support `.epub`, so functionality was added to force all emails to kindle as `.mobi`. 

Than in #84 - it was noted that Kindle now supports `.epub` and will be deprecating support for `.mobi`. As a result I switched the logic to send all kindle requests as `.epub`.

There's now reports though that people are getting errors sending files via `.epub` and need `.mobi` 🤔.

To fix this and allow people to choose either, I'm removing the logic.

